### PR TITLE
Ensure that logging is disabled consistently

### DIFF
--- a/lib/vero/api/base_api.rb
+++ b/lib/vero/api/base_api.rb
@@ -29,7 +29,7 @@ module Vero
 
         protected
         def setup_logging
-          return unless Vero::App.logger
+          return unless Vero::App.logging_enabled?
 
           RestClient.log = Object.new.tap do |proxy|
             def proxy.<<(message)

--- a/lib/vero/utility/logger.rb
+++ b/lib/vero/utility/logger.rb
@@ -27,7 +27,7 @@ module Vero
         end
 
         def logging_enabled?
-          logger && Vero::App.default_context.config.logging && !defined(RSpec)
+          logger && (Vero::App.default_context.config.logging || defined(RSpec))
         end
       end
     end

--- a/lib/vero/utility/logger.rb
+++ b/lib/vero/utility/logger.rb
@@ -7,7 +7,7 @@ module Vero
 
       module ClassMethods
         def log(object, message)
-          return unless Vero::App.default_context.config.logging && !defined?(RSpec)
+          return unless logging_enabled?
 
           message = "#{object.class.name}: #{message}"
 
@@ -24,6 +24,10 @@ module Vero
           else
             nil
           end
+        end
+
+        def logging_enabled?
+          logger && Vero::App.default_context.config.logging && !defined(RSpec)
         end
       end
     end

--- a/lib/vero/utility/logger.rb
+++ b/lib/vero/utility/logger.rb
@@ -27,7 +27,7 @@ module Vero
         end
 
         def logging_enabled?
-          logger && (Vero::App.default_context.config.logging || defined(RSpec))
+          logger && (Vero::App.default_context.config.logging || defined?(RSpec))
         end
       end
     end


### PR DESCRIPTION
## Context

There are currently two different logging methods that are using different logic, which results in HTTP calls being logged when outside the "test" environment - when running in production, `Rails` logging is disabled, but `RestClient` logging cannot be disabled.

`RestClient` uses the existence of `Vero::App.logger`, which is always created if `Rails` is defined.

## Changes

* Made a new method to determine whether to log, and use it for Rails and RestClient logging

now, log if: `we have a logger AND (we've enabled logging in config OR we are in the test environment)`